### PR TITLE
Add manifests for deploy minio

### DIFF
--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ к лекции № 6

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - добавлены манифесты для деплоя minio

## Как запустить проект:
 - k apply -f kubernetes-volumes/minio-statefulset.yaml
 - k apply -f kubernetes-volumes/minio-headless-service.yaml

## Как проверить работоспособность:
  - k get all

## PR checklist:
 - [x] Выставлен label с номером домашнего задания